### PR TITLE
feat: 커뮤니티 API 연동 - 게시물 조회, 댓글 조회

### DIFF
--- a/UMC-Kitten-iOS/Domain/Model/PostModel.swift
+++ b/UMC-Kitten-iOS/Domain/Model/PostModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// 자유게시판 글 정보
-struct PostModel {
+struct PostModel: Codable {
     /// 게시판
     var boardType: BoardType
     /// 사진

--- a/UMC-Kitten-iOS/SceneDelegate.swift
+++ b/UMC-Kitten-iOS/SceneDelegate.swift
@@ -41,6 +41,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         checkinNavVC.viewControllers = [checkinVC]
         
         let communityVC = CommunityViewController()
+        let communityNavVC = UINavigationController()
+        communityNavVC.viewControllers = [communityVC]
         
         let mypageVC = MypageViewController()
         let mypageNavVC = UINavigationController()
@@ -54,7 +56,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         mypageVC.title = "마이페이지"
         
         // (3) Tab Bar로 사용하기 위한 뷰 컨트롤러들 설정
-        tabBarVC.setViewControllers([homeNavVC, checkinNavVC, communityVC, mypageNavVC], animated: false)
+        tabBarVC.setViewControllers([homeNavVC, checkinNavVC, communityNavVC, mypageNavVC], animated: false)
         tabBarVC.modalPresentationStyle = .fullScreen
         tabBarVC.tabBar.backgroundColor = .white
         tabBarVC.tabBar.tintColor = .main

--- a/UMC-Kitten-iOS/View/Community/Community/CommunityView.swift
+++ b/UMC-Kitten-iOS/View/Community/Community/CommunityView.swift
@@ -42,17 +42,10 @@ final class CommunityView: UIView {
         return button
     }()
     
-    let fourthTapButton: UIButton = {
-        let button = UIButton(type: .custom)
-        button.setTitle("입양/실종", for: .normal)
-        button.setTitleColor(UIColor(red: 0.596, green: 0.596, blue: 0.62, alpha: 1), for: .normal)
-        return button
-    }()
-    
     lazy var tapStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [firstTapButton, secondTapButton, thirdTapButton, fourthTapButton])
+        let stackView = UIStackView(arrangedSubviews: [firstTapButton, secondTapButton, thirdTapButton])
         stackView.axis = .horizontal
-        stackView.distribution = .equalSpacing
+        stackView.distribution = .fillEqually
         stackView.alignment = .center
         return stackView
     }()

--- a/UMC-Kitten-iOS/View/Community/Community/FreeBoardTableViewCell.swift
+++ b/UMC-Kitten-iOS/View/Community/Community/FreeBoardTableViewCell.swift
@@ -145,7 +145,7 @@ final class FreeBoardTableViewCell: UITableViewCell {
         
         contentImage.snp.makeConstraints {
             $0.top.equalTo(summaryWithoutCommentImageStackView.snp.top)
-            $0.leading.equalTo(summaryWithoutCommentImageStackView.snp.trailing)
+            $0.leading.equalTo(summaryWithoutCommentImageStackView.snp.trailing).offset(10)
             $0.trailing.equalToSuperview().offset(-27)
             $0.bottom.equalTo(summaryWithoutCommentImageStackView.snp.bottom)
             $0.width.equalTo(self.contentImage.snp.height)

--- a/UMC-Kitten-iOS/View/Community/FreeBoardDetailViewController.swift
+++ b/UMC-Kitten-iOS/View/Community/FreeBoardDetailViewController.swift
@@ -11,6 +11,7 @@ class FreeBoardDetailViewController: UIViewController {
 
     // MARK: - 프로퍼티
     let freeBoardDetailView = FreeBoardDetailView()
+    var post: PostResponseDto.PostPreviewDto?
     
     // MARK: - 라이프 사이클
     override func loadView() {
@@ -51,45 +52,49 @@ extension FreeBoardDetailViewController: UITableViewDelegate {
 
 extension FreeBoardDetailViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 11
+        return 1 + (post?.commentPreviewListDTO.commentList.count ?? 0)
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.row == 0 {
             let cell = tableView.dequeueReusableCell(withIdentifier: "FreeBoardDetailContentTableViewCell", for: indexPath) as! FreeBoardDetailContentTableViewCell
             
-            cell.nicknameLabel.text = "냥뭉이"
-            cell.uploadDateLabel.text = "20분 전"
-            cell.titleLabel.text = "강아지 목에 이상한 멍울 자국 관련 문의"
-            cell.contentLabel.text = "새해에는 새롭게 출발하는 거야!\n오늘도 냥이와 함께하는 하루일과!"
-            cell.heartCountLabel.text = "20"
-            cell.commentCountLabel.text = "1"
+            cell.nicknameLabel.text = post?.writerNickName
+            cell.uploadDateLabel.text = post?.createdAt.timeAgoDisplay()
+            cell.titleLabel.text = post?.title
+            cell.contentLabel.text = post?.content
+            cell.heartCountLabel.text = "\(post?.likePreviewListDTO.listSize ?? 0)"
+            cell.commentCountLabel.text = "\(post?.commentPreviewListDTO.listSize ?? 0)"
             
             cell.contentCellDelegate = self
-            
-            cell.selectionStyle = .none
-            
-            return cell
-        } else if indexPath.row % 2 == 1 {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "FreeBoardDetailCommentTableViewCell", for: indexPath) as! FreeBoardDetailCommentTableViewCell
-            
-            cell.userNameLabel.text = "냥뭉이"
-            cell.userCommentLabel.text = "너무 귀여워요!"
-            cell.heartCountLabel.text = "25"
-
             cell.selectionStyle = .none
             
             return cell
         } else {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "FreeBoardDetailNestedCommentTableViewCell", for: indexPath) as! FreeBoardDetailNestedCommentTableViewCell
-            
-            cell.userNameLabel.text = "냥뭉이"
-            cell.userCommentLabel.text = "너무 귀여워요!"
-            
+            let cell = tableView.dequeueReusableCell(withIdentifier: "FreeBoardDetailCommentTableViewCell", for: indexPath) as! FreeBoardDetailCommentTableViewCell
+
+            // 댓글 데이터를 가져오기
+            let comment = post?.commentPreviewListDTO.commentList[indexPath.row - 1]
+            /// 댓글 Dto에 참조된 데이터들이 너무 꼬여있어 일부분만 받아서 댓글 닉네임을 따로 뽑진 못했습니다!
+            cell.userNameLabel.text = "회원 \(indexPath.row)"
+            cell.userCommentLabel.text = comment?.content
+            cell.heartCountLabel.text = "0"
+
             cell.selectionStyle = .none
-            
+
             return cell
         }
+        /// 대댓글은 구현 X
+//        else {
+//            let cell = tableView.dequeueReusableCell(withIdentifier: "FreeBoardDetailNestedCommentTableViewCell", for: indexPath) as! FreeBoardDetailNestedCommentTableViewCell
+//            
+//            cell.userNameLabel.text = "냥뭉이"
+//            cell.userCommentLabel.text = "너무 귀여워요!"
+//            
+//            cell.selectionStyle = .none
+//            
+//            return cell
+//        }
     }
 }
 


### PR DESCRIPTION
### FEAT 내용
- 커뮤니티 게시물 조회 API 호출  ( 하단 탭에서 커뮤니티 접속 시 또는 커뮤니티 내의 탭 클릭 시 )

- 커뮤니티 댓글 조회 ( 게시물 조회 API의 commentDTO가 복잡해서 필요 데이터만 뽑고 회원1, 회원2와 같은 닉네임으로 표기)

- 커뮤니티 레이아웃 안정화
